### PR TITLE
Add manual build information for cygwin users

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ $ make
 $ make install
 ```
 
+**For Cygwin users:** Currently, you need to pass some options to `cmake` like below (for more detail, see [#93](https://github.com/poacpm/poac/issues/93)):
+
+```bash
+cmake .. -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW -Wa,-mbig-obj"
+```
+
 Already poac is installed, you can build using poac:
 ```bash
 $ poac build


### PR DESCRIPTION
関連issue: #93 

TODO: Cygwin上で普通にビルドできるようになったらこのコミットをrevertする．