### PR TITLE
Add manual build information for some Linux users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,4 +57,11 @@ if(WIN32)
     target_link_libraries(${PROJECT_NAME} "-lbcrypt" "-lws2_32")
 endif()
 
+if(UNIX AND NOT APPLE)
+    add_definitions(-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW)
+elseif(CYGWIN)
+    add_definitions(-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW -Wa, -mbing-obj)
+endif()
+
+
 install(TARGETS poac DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,5 +63,4 @@ elseif(CYGWIN)
     add_definitions(-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW -Wa, -mbing-obj)
 endif()
 
-
 install(TARGETS poac DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cmake .. -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW -Wa,-
 **For Linux users:** Currently, you need to pass some options to `cmake` like below:
 
 ```bash
-cmake .. -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW"
+cmake .. -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW -lboost_system"
 ```
 <!--
 If poac is already installed, you can build using poac:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cmake .. -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW -Wa,-
 **For Linux users:** Currently, you need to pass some options to `cmake` like below:
 
 ```bash
-cmake .. -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW -lboost_system"
+cmake .. -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW"
 ```
 <!--
 If poac is already installed, you can build using poac:

--- a/README.md
+++ b/README.md
@@ -49,11 +49,6 @@ $ make install
 cmake .. -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW -Wa,-mbig-obj"
 ```
 
-**For Linux users:** Currently, you need to pass some options to `cmake` like below:
-
-```bash
-cmake .. -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW -lboost_system"
-```
 <!--
 If poac is already installed, you can build using poac:
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ $ make install
 cmake .. -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW -Wa,-mbig-obj"
 ```
 
+**For Linux users:** Currently, you need to pass some options to `cmake` like below:
+
+```bash
+cmake .. -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW -lboost_system"
+```
 <!--
 If poac is already installed, you can build using poac:
 ```bash


### PR DESCRIPTION
I was not able to compile the poac on fedora 28 when following the manual install instruction.
However I tried to compile it with the cmake option ` -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -DBOOST_ASIO_HAS_STD_STRING_VIEW"`, and compile success.
I removes `-Wa,-mbig-obj` from Cygwin version because it causes the error on fedora 28.

boost version is 1.66.0-8, which is the latest version from dnf on fedora 28.

Although this commit is tentative, it might be helpful for some Linux users for now.