### PR TITLE
offer AUR distribution of poac to Arch Linux users on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ curl -fsSL https://sh.poac.pm | bash
 ```
 *When your OS is macOS, use [Homebrew](https://github.com/Homebrew/brew)*
 
+*For Arch Linux users, there are AUR packages: [poac](https://aur.archlinux.org/packages/poac/), [poac-devel-git](https://aur.archlinux.org/packages/poac-devel-git), [poac-git](https://aur.archlinux.org/packages/poac-git)*
+
 ### Manual install (Build)
 
 Poac requires the following tools and packages to build:


### PR DESCRIPTION
poac is now available in Arch User Repository. (#195)
This request will add a sentence offering AUR distribution of poac to README.md

Installation in Arch Linux can be done with the command like the following.

```console
~ $ yay -S poac
```