### PR TITLE
Revert the commit hash of Ninja

### DIFF
--- a/cmake/AddNinja.cmake
+++ b/cmake/AddNinja.cmake
@@ -5,8 +5,8 @@ list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
 FetchContent_Declare(
         ninja
-        GIT_REPOSITORY https://github.com/ken-matsui/ninja
-        GIT_TAG        f40aff4287b84ebfa737cd75ab26676df82d9293
+        GIT_REPOSITORY https://github.com/ninja-build/ninja
+        GIT_TAG        1d4034f0ac2b5cfb809b5ab983d47c3cb2c78415
 )
 
 set(BUILD_TESTING OFF)


### PR DESCRIPTION
The commit hash of `ken-matsui/ninja` is at risk of deleting.