### PR TITLE
Avoid providing Poac libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,11 @@ if (NOT APPLE AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif ()
 
 add_subdirectory(lib)
-target_link_libraries(poac ${STATIC_LINK_FLAG}
+target_link_libraries(poac PRIVATE
+    ${STATIC_LINK_FLAG}
     poac_cmd
     poac_util_lev_distance
+    ${NINJA_LIBRARIES} # TODO: this should be propagated from poac_core_builder_ninja
 )
 
 set(CONFIG_VERSION_FILE ${CMAKE_CURRENT_BINARY_DIR}/poac-config-version.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ if (NOT APPLE AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     list(APPEND POAC_DEPENDENCIES "-lstdc++fs")
 endif ()
 
+include(cmake/Helpers.cmake)
 add_subdirectory(lib)
 target_link_libraries(poac PRIVATE
     ${STATIC_LINK_FLAG}

--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -16,3 +16,35 @@ if (APPLE)
     get_homebrew_prefix_path()
     set(POAC_HOMEBREW_ROOT_PATH "${POAC_HOMEBREW_PREFIX_PATH}/opt")
 endif()
+
+# If no sources are provided, then only an interface target will be added.
+function (add_poac_target target_name)
+    cmake_parse_arguments(VARS "" "" "SOURCES;INCLUDES;LIBRARIES;DEFINES" ${ARGN})
+
+    add_library(${target_name} INTERFACE) # prepare an interface target for dependents
+    target_compile_features(${target_name} INTERFACE cxx_std_20)
+    target_compile_definitions(${target_name} INTERFACE ${VARS_DEFINES})
+    target_include_directories(${target_name} INTERFACE ${VARS_INCLUDES})
+
+    list(LENGTH VARS_SOURCES SOURCE_COUNT)
+    if (${SOURCE_COUNT} GREATER 0)
+        add_library(${target_name}_obj OBJECT ${VARS_SOURCES})
+        target_compile_features(${target_name}_obj PUBLIC cxx_std_20)
+        target_compile_definitions(${target_name}_obj PUBLIC ${VARS_DEFINES})
+
+        target_include_directories(${target_name}_obj PUBLIC ${VARS_INCLUDES})
+        target_link_libraries(${target_name}_obj PUBLIC ${STATIC_LINK_FLAG} ${VARS_LIBRARIES})
+
+        target_link_libraries(${target_name} INTERFACE
+            ${STATIC_LINK_FLAG}
+            ${VARS_LIBRARIES}
+            ${target_name}_obj
+            $<TARGET_OBJECTS:${target_name}_obj>
+        )
+    else ()
+        target_link_libraries(${target_name} INTERFACE
+            ${STATIC_LINK_FLAG}
+            ${VARS_LIBRARIES}
+        )
+    endif ()
+endfunction ()

--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -19,17 +19,23 @@ endif()
 
 # If no sources are provided, then only an interface target will be added.
 function (add_poac_target target_name)
-    cmake_parse_arguments(VARS "" "" "SOURCES;INCLUDES;LIBRARIES;DEFINES" ${ARGN})
+    cmake_parse_arguments(VARS "" "CXX" "SOURCES;INCLUDES;LIBRARIES;DEFINES" ${ARGN})
+
+    if (NOT DEFINED VARS_CXX)
+        set(VARS_CXX_STD cxx_std_20)
+    else ()
+        set(VARS_CXX_STD cxx_std_${VARS_CXX})
+    endif ()
 
     add_library(${target_name} INTERFACE) # prepare an interface target for dependents
-    target_compile_features(${target_name} INTERFACE cxx_std_20)
+    target_compile_features(${target_name} INTERFACE ${VARS_CXX_STD})
     target_compile_definitions(${target_name} INTERFACE ${VARS_DEFINES})
     target_include_directories(${target_name} INTERFACE ${VARS_INCLUDES})
 
     list(LENGTH VARS_SOURCES SOURCE_COUNT)
     if (${SOURCE_COUNT} GREATER 0)
         add_library(${target_name}_obj OBJECT ${VARS_SOURCES})
-        target_compile_features(${target_name}_obj PUBLIC cxx_std_20)
+        target_compile_features(${target_name}_obj PUBLIC ${VARS_CXX_STD})
         target_compile_definitions(${target_name}_obj PUBLIC ${VARS_DEFINES})
 
         target_include_directories(${target_name}_obj PUBLIC ${VARS_INCLUDES})

--- a/lib/cmd/CMakeLists.txt
+++ b/lib/cmd/CMakeLists.txt
@@ -1,33 +1,28 @@
-add_library(poac_cmd
-    build.cc
-    create.cc
-    fmt.cc
-    graph.cc
-    init.cc
-    lint.cc
-    login.cc
-    publish.cc
-    run.cc
-    search.cc
-)
+include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
 
-target_compile_features(poac_cmd PUBLIC cxx_std_20)
-target_include_directories(poac_cmd PUBLIC
-    ${CMAKE_HOME_DIRECTORY}/include
-    ${Boost_INCLUDE_DIRS}
-    ${LIBGIT2_INCLUDE_DIR}
-)
-target_link_libraries(poac_cmd PUBLIC
-    ${STATIC_LINK_FLAG}
-
-    ${POAC_HPP_LIBS}
-    structopt::structopt
-    toml11::toml11
-    ${LIBGIT2_LIBRARY}
-    git2-cpp::git2-cpp
-    Glob
-
-    poac_core
-    poac_util_pretty
-    poac_util_net
+add_poac_target(poac_cmd
+    SOURCES
+        build.cc
+        create.cc
+        fmt.cc
+        graph.cc
+        init.cc
+        lint.cc
+        login.cc
+        publish.cc
+        run.cc
+        search.cc
+    INCLUDES
+        ${POAC_HPP_INCLUDES}
+        ${LIBGIT2_INCLUDE_DIR}
+    LIBRARIES
+        ${POAC_HPP_LIBS}
+        structopt::structopt
+        toml11::toml11
+        ${LIBGIT2_LIBRARY}
+        git2-cpp::git2-cpp
+        Glob
+        poac_core
+        poac_util_pretty
+        poac_util_net
 )

--- a/lib/cmd/CMakeLists.txt
+++ b/lib/cmd/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
-
 add_poac_target(poac_cmd
     SOURCES
         build.cc

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -1,26 +1,20 @@
-add_library(poac_core
-    resolver.cc
-    validator.cc
-)
+include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
 
-target_compile_features(poac_core PUBLIC cxx_std_20)
-target_include_directories(poac_core PUBLIC
-    ${CMAKE_HOME_DIRECTORY}/include
-    ${Boost_INCLUDE_DIRS}
-    ${LIBARCHIVE_INCLUDE_DIR}
-)
-target_link_libraries(poac_core PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${POAC_HPP_LIBS}
-    ${LIBARCHIVE_LIBRARY}
-    poac_core_builder_ninja
-    poac_core_resolver
-    poac_data
-    poac_util_archive
-    poac_util_sha256
-    poac_util_semver
-    poac_util_misc # via poac/config.hpp
-    toml11::toml11
+add_poac_target(poac_core
+    SOURCES
+        resolver.cc
+        validator.cc
+    INCLUDES ${POAC_HPP_INCLUDES}
+    LIBRARIES
+        ${POAC_HPP_LIBS}
+        poac_core_builder_ninja
+        poac_core_resolver
+        poac_data
+        poac_util_archive
+        poac_util_sha256
+        poac_util_semver
+        poac_util_misc # via poac/config.hpp
+        toml11::toml11
 )
 
 add_subdirectory(builder)

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
-
 add_poac_target(poac_core
     SOURCES
         resolver.cc

--- a/lib/core/builder/compiler/cxx/CMakeLists.txt
+++ b/lib/core/builder/compiler/cxx/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
-
 add_poac_target(poac_core_builder_compiler_cxx
     SOURCES
         apple_clang.cc

--- a/lib/core/builder/compiler/cxx/CMakeLists.txt
+++ b/lib/core/builder/compiler/cxx/CMakeLists.txt
@@ -1,19 +1,16 @@
-add_library(poac_core_builder_compiler_cxx
-    apple_clang.cc
-    clang.cc
-    cxx.cc
-    gcc.cc
-)
+include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
 
-target_compile_features(poac_core_builder_compiler_cxx PUBLIC cxx_std_20)
-target_include_directories(poac_core_builder_compiler_cxx PUBLIC
-    ${CMAKE_HOME_DIRECTORY}/include
-)
-target_link_libraries(poac_core_builder_compiler_cxx PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${POAC_HPP_LIBS}
-    poac_core_builder_compiler_lang
-    poac_util_cfg
-    poac_util_semver
-    poac_util_misc # in cxx.cc
+add_poac_target(poac_core_builder_compiler_cxx
+    SOURCES
+        apple_clang.cc
+        clang.cc
+        cxx.cc
+        gcc.cc
+    INCLUDES ${POAC_HPP_INCLUDES}
+    LIBRARIES
+        ${POAC_HPP_LIBS}
+        poac_core_builder_compiler_lang
+        poac_util_cfg
+        poac_util_semver
+        poac_util_misc # in cxx.cc
 )

--- a/lib/core/builder/compiler/lang/CMakeLists.txt
+++ b/lib/core/builder/compiler/lang/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
-
 add_poac_target(poac_core_builder_compiler_lang
     SOURCES
         error.cc

--- a/lib/core/builder/compiler/lang/CMakeLists.txt
+++ b/lib/core/builder/compiler/lang/CMakeLists.txt
@@ -1,14 +1,11 @@
-add_library(poac_core_builder_compiler_lang
-    error.cc
-    lang.cc
-)
+include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
 
-target_compile_features(poac_core_builder_compiler_lang PUBLIC cxx_std_20)
-target_include_directories(poac_core_builder_compiler_lang PUBLIC
-    ${CMAKE_HOME_DIRECTORY}/include
-)
-target_link_libraries(poac_core_builder_compiler_lang PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${POAC_HPP_LIBS}
-    poac_util_cfg
+add_poac_target(poac_core_builder_compiler_lang
+    SOURCES
+        error.cc
+        lang.cc
+    INCLUDES ${POAC_HPP_INCLUDES}
+    LIBRARIES
+        ${POAC_HPP_LIBS}
+        poac_util_cfg
 )

--- a/lib/core/builder/ninja/CMakeLists.txt
+++ b/lib/core/builder/ninja/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
-
 add_poac_target(poac_core_builder_ninja
     SOURCES
         build.cc

--- a/lib/core/builder/ninja/CMakeLists.txt
+++ b/lib/core/builder/ninja/CMakeLists.txt
@@ -1,24 +1,21 @@
-add_library(poac_core_builder_ninja
-    build.cc
-    log.cc
-    manifest.cc
-    syntax.cc
-)
+include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
 
-target_compile_features(poac_core_builder_ninja PUBLIC cxx_std_20)
-target_include_directories(poac_core_builder_ninja PUBLIC
-    ${CMAKE_HOME_DIRECTORY}/include
-    ${Boost_INCLUDE_DIRS}
-    ${NINJA_INCLUDE_DIR}
-)
-target_link_libraries(poac_core_builder_ninja PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${POAC_HPP_LIBS}
-    ${NINJA_LIBRARIES}
-    Boost::regex
-    toml11::toml11
-    poac_util_cfg
-    poac_util_pretty
-    poac_core_builder_compiler_cxx
-    poac_core_resolver
+add_poac_target(poac_core_builder_ninja
+    SOURCES
+        build.cc
+        log.cc
+        manifest.cc
+        syntax.cc
+    INCLUDES
+        ${POAC_HPP_INCLUDES}
+        ${NINJA_INCLUDE_DIR}
+    LIBRARIES
+        ${POAC_HPP_LIBS}
+        ${NINJA_LIBRARIES}
+        Boost::regex
+        toml11::toml11
+        poac_util_cfg
+        poac_util_pretty
+        poac_core_builder_compiler_cxx
+        poac_core_resolver
 )

--- a/lib/core/resolver/CMakeLists.txt
+++ b/lib/core/resolver/CMakeLists.txt
@@ -1,19 +1,14 @@
-add_library(poac_core_resolver
-    sat.cc
-    resolve.cc
-)
-
-target_compile_features(poac_core_resolver PUBLIC cxx_std_20)
-target_include_directories(poac_core_resolver PUBLIC
-    ${CMAKE_HOME_DIRECTORY}/include
-    ${Boost_INCLUDE_DIRS}
-    ${OPENSSL_INCLUDE_DIR}
-)
-target_link_libraries(poac_core_resolver PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${POAC_HPP_LIBS}
-    poac_util_net
-    poac_util_semver
-    poac_util_misc
-    poac_util_pretty
+add_poac_target(poac_core_resolver
+    SOURCES
+        sat.cc
+        resolve.cc
+    INCLUDES
+        ${POAC_HPP_INCLUDES}
+        ${OPENSSL_INCLUDE_DIR}
+    LIBRARIES
+        ${POAC_HPP_LIBS}
+        poac_util_net
+        poac_util_semver
+        poac_util_misc
+        poac_util_pretty
 )

--- a/lib/data/CMakeLists.txt
+++ b/lib/data/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
-
 add_poac_target(poac_data
     SOURCES lockfile.cc
     DEFINES TOML11_NO_ERROR_PREFIX

--- a/lib/data/CMakeLists.txt
+++ b/lib/data/CMakeLists.txt
@@ -1,15 +1,11 @@
-add_library(poac_data
-    lockfile.cc
-)
+include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
 
-target_compile_features(poac_data PUBLIC cxx_std_20)
-target_compile_definitions(poac_data PUBLIC TOML11_NO_ERROR_PREFIX)
-target_include_directories(poac_data PUBLIC
-    ${CMAKE_HOME_DIRECTORY}/include
-)
-target_link_libraries(poac_data PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${POAC_HPP_LIBS}
-    toml11::toml11
-    poac_core_resolver
+add_poac_target(poac_data
+    SOURCES lockfile.cc
+    DEFINES TOML11_NO_ERROR_PREFIX
+    INCLUDES ${POAC_HPP_INCLUDES}
+    LIBRARIES
+        ${POAC_HPP_LIBS}
+        toml11::toml11
+        poac_core_resolver
 )

--- a/lib/util/CMakeLists.txt
+++ b/lib/util/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
-
 add_poac_target(poac_util_archive
     SOURCES archive.cc
     INCLUDES

--- a/lib/util/CMakeLists.txt
+++ b/lib/util/CMakeLists.txt
@@ -1,82 +1,75 @@
-add_library(poac_util_archive OBJECT archive.cc)
-add_library(poac_util_cfg OBJECT cfg.cc)
-add_library(poac_util_lev_distance OBJECT lev_distance.cc)
-add_library(poac_util_misc OBJECT misc.cc)
-add_library(poac_util_pretty OBJECT pretty.cc)
-add_library(poac_util_sha256 OBJECT sha256.cc)
-add_library(poac_util_net OBJECT net.cc)
+include(${CMAKE_SOURCE_DIR}/cmake/Helpers.cmake)
 
-target_compile_features(poac_util_archive PUBLIC cxx_std_20)
-target_compile_features(poac_util_cfg PUBLIC cxx_std_20)
-target_compile_features(poac_util_lev_distance PUBLIC cxx_std_20)
-target_compile_features(poac_util_misc PUBLIC cxx_std_20)
-target_compile_features(poac_util_pretty PUBLIC cxx_std_20)
-target_compile_features(poac_util_sha256 PUBLIC cxx_std_20)
-target_compile_features(poac_util_net PUBLIC cxx_std_20)
-
-target_include_directories(poac_util_archive PUBLIC
-    ${POAC_HPP_INCLUDES}
-    ${LIBARCHIVE_INCLUDE_DIR}
-)
-target_link_libraries(poac_util_archive PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${POAC_HPP_LIBS}
-    ${LIBARCHIVE_LIBRARY}
+add_poac_target(poac_util_archive
+    SOURCES archive.cc
+    INCLUDES
+        ${POAC_HPP_INCLUDES}
+        ${LIBARCHIVE_INCLUDE_DIR}
+    LIBRARIES
+        ${POAC_HPP_LIBS}
+        ${LIBARCHIVE_LIBRARY}
 )
 
-target_include_directories(poac_util_cfg PUBLIC
-    ${POAC_HPP_INCLUDES}
-)
-target_link_libraries(poac_util_cfg PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${POAC_HPP_LIBS}
+add_poac_target(poac_util_cfg
+    SOURCES cfg.cc
+    INCLUDES ${POAC_HPP_INCLUDES}
+    LIBRARIES ${POAC_HPP_LIBS}
 )
 
-target_include_directories(poac_util_lev_distance PUBLIC
-    ${POAC_HPP_INCLUDES}
-)
-target_link_libraries(poac_util_lev_distance PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${POAC_HPP_LIBS}
+add_poac_target(poac_util_lev_distance
+    SOURCES lev_distance.cc
+    INCLUDES ${POAC_HPP_INCLUDES}
+    LIBRARIES ${POAC_HPP_LIBS}
 )
 
-target_include_directories(poac_util_misc PUBLIC
-    ${POAC_HPP_INCLUDES}
-)
-target_link_libraries(poac_util_misc PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${POAC_HPP_LIBS}
+add_poac_target(poac_util_meta
+    INCLUDES ${POAC_HPP_INCLUDES}
+    LIBRARIES ${POAC_HPP_LIBS}
 )
 
-target_include_directories(poac_util_pretty PUBLIC
-    ${POAC_HPP_INCLUDES}
-)
-target_link_libraries(poac_util_pretty PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${POAC_HPP_LIBS}
+add_poac_target(poac_util_misc
+    SOURCES misc.cc
+    INCLUDES ${POAC_HPP_INCLUDES}
+    LIBRARIES ${POAC_HPP_LIBS}
 )
 
-target_include_directories(poac_util_sha256 PUBLIC
-    ${POAC_HPP_INCLUDES}
-    ${OPENSSL_INCLUDE_DIR}
-)
-target_link_libraries(poac_util_sha256 PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${OPENSSL_LIBRARIES}
-    ${POAC_HPP_LIBS}
+add_poac_target(poac_util_net
+    SOURCES net.cc
+    INCLUDES
+        ${POAC_HPP_INCLUDES}
+        ${Boost_INCLUDE_DIRS}
+        ${OPENSSL_INCLUDE_DIR}
+    LIBRARIES
+        ${OPENSSL_LIBRARIES}
+        poac_util_misc
+        poac_util_pretty
+        ${POAC_HPP_LIBS}
 )
 
-target_include_directories(poac_util_net PUBLIC
-    ${POAC_HPP_INCLUDES}
-    ${Boost_INCLUDE_DIRS}
-    ${OPENSSL_INCLUDE_DIR}
+add_poac_target(poac_util_pretty
+    SOURCES pretty.cc
+    INCLUDES ${POAC_HPP_INCLUDES}
+    LIBRARIES ${POAC_HPP_LIBS}
 )
-target_link_libraries(poac_util_net PUBLIC
-    ${STATIC_LINK_FLAG}
-    ${OPENSSL_LIBRARIES}
-    poac_util_misc
-    poac_util_pretty
-    ${POAC_HPP_LIBS}
+
+add_poac_target(poac_util_sha256
+    SOURCES sha256.cc
+    INCLUDES
+        ${POAC_HPP_INCLUDES}
+        ${OPENSSL_INCLUDE_DIR}
+    LIBRARIES
+        ${POAC_HPP_LIBS}
+        ${OPENSSL_LIBRARIES}
+)
+
+add_poac_target(poac_util_shell
+    INCLUDES ${POAC_HPP_INCLUDES}
+    LIBRARIES ${POAC_HPP_LIBS}
+)
+
+add_poac_target(poac_util_verbosity
+    INCLUDES ${POAC_HPP_INCLUDES}
+    LIBRARIES ${POAC_HPP_LIBS}
 )
 
 add_subdirectory(semver)

--- a/lib/util/semver/CMakeLists.txt
+++ b/lib/util/semver/CMakeLists.txt
@@ -1,15 +1,11 @@
-add_library(poac_util_semver
-    comparison.cc
-    interval.cc
-    lexer.cc
-    parser.cc
-    token.cc
-)
-target_compile_features(poac_util_semver PUBLIC cxx_std_17)
-target_include_directories(poac_util_semver PUBLIC
-    ${CMAKE_HOME_DIRECTORY}/include
-)
-target_link_libraries(poac_util_semver PUBLIC
-    ${STATIC_LINK_FLAG}
-    fmt::fmt
+add_poac_target(poac_util_semver
+    CXX 17
+    SOURCES
+        comparison.cc
+        interval.cc
+        lexer.cc
+        parser.cc
+        token.cc
+    INCLUDES ${CMAKE_HOME_DIRECTORY}/include
+    LIBRARIES fmt::fmt
 )

--- a/tests/unit/core/CMakeLists.txt
+++ b/tests/unit/core/CMakeLists.txt
@@ -15,6 +15,7 @@ foreach (TEST_NAME ${TEST_NAMES})
     target_link_libraries(${TEST_NAME} PRIVATE
         Boost::ut
         poac_core
+        ${NINJA_LIBRARIES} # TODO: this should be propagated from poac_core_builder_ninja
     )
     add_test(
         NAME "${TEST_NAME_PREFIX}/${TEST_NAME}"

--- a/tests/unit/core/builder/ninja/CMakeLists.txt
+++ b/tests/unit/core/builder/ninja/CMakeLists.txt
@@ -15,6 +15,7 @@ foreach (TEST_NAME ${TEST_NAMES})
     target_link_libraries(${TEST_NAME} PRIVATE
         Boost::ut
         poac_core_builder_ninja
+        ${NINJA_LIBRARIES} # TODO: this should be propagated from poac_core_builder_ninja
     )
     add_test(
         NAME "${TEST_NAME_PREFIX}/${TEST_NAME}"

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -14,7 +14,6 @@ set(TEST_NAMES
 
 foreach (TEST_NAME ${TEST_NAMES})
     add_executable(${TEST_NAME} ${TEST_NAME}.cc)
-    target_compile_features(${TEST_NAME} PRIVATE cxx_std_20)
 
     if (POAC_ENABLE_COVERAGE)
         target_compile_options(${TEST_NAME} PRIVATE -g -O0 --coverage)
@@ -23,23 +22,7 @@ foreach (TEST_NAME ${TEST_NAMES})
         target_compile_options(${TEST_NAME} PRIVATE -g -O0)
     endif ()
 
-    if (${TEST_NAME} STREQUAL "meta" OR ${TEST_NAME} STREQUAL "shell" OR ${TEST_NAME} STREQUAL "verbosity")
-        target_include_directories(${TEST_NAME} PUBLIC
-            ${CMAKE_HOME_DIRECTORY}/include
-            ${Boost_INCLUDE_DIRS}
-        )
-        target_link_libraries(${TEST_NAME} PRIVATE
-            Boost::ut
-            fmt::fmt
-            mitama-cpp-result::mitama-cpp-result
-            spdlog::spdlog
-        )
-    else ()
-        target_link_libraries(${TEST_NAME} PRIVATE Boost::ut "poac_util_${TEST_NAME}")
-        if (${TEST_NAME} STREQUAL "net")
-            target_link_libraries(${TEST_NAME} PRIVATE poac_util_pretty poac_util_misc) # FIXME: why needed?
-        endif ()
-    endif ()
+    target_link_libraries(${TEST_NAME} PRIVATE Boost::ut "poac_util_${TEST_NAME}")
 
     add_test(
         NAME "${TEST_NAME_PREFIX}/${TEST_NAME}"


### PR DESCRIPTION
Related to: https://github.com/macports/macports-ports/pull/15429

Libraries of Poac should not be provided since they are not designed to be used by others.