### PR TITLE
Fix subcommand suggestion

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -184,7 +184,7 @@ main(const int argc, char* argv[]) {
         .is_err();
   } catch (const structopt::exception& e) {
     if (argc > 1) {
-      int subcommand_index = 1;
+      i32 subcommand_index = 1;
       for (; subcommand_index < argc; ++subcommand_index) {
         if (argv[subcommand_index][0] != '-') {
           break;

--- a/src/main.cc
+++ b/src/main.cc
@@ -184,9 +184,15 @@ main(const int argc, char* argv[]) {
         .is_err();
   } catch (const structopt::exception& e) {
     if (argc > 1) {
+      int subcommand_index = 1;
+      for (; subcommand_index < argc; ++subcommand_index)
+        if (argv[subcommand_index][0] != '-')
+          break;
+
       // try correcting typo
-      if (const auto sugg =
-              util::lev_distance::find_similar_str(argv[1], command_list)) {
+      if (const auto sugg = util::lev_distance::find_similar_str(
+              argv[subcommand_index], command_list
+          )) {
         err_logger->error(
             "{}\n"
             "  --> Did you mean `{}`?\n\n"

--- a/src/main.cc
+++ b/src/main.cc
@@ -193,7 +193,7 @@ main(const int argc, char* argv[]) {
       if (const auto sugg = util::lev_distance::find_similar_str(
               argv[subcommand_index], command_list
           );
-          sugg && *sugg != argv[subcommand_index]) {
+          sugg.has_value() && sugg.value() != argv[subcommand_index]) {
         err_logger->error(
             "{}\n"
             "  --> Did you mean `{}`?\n\n"

--- a/src/main.cc
+++ b/src/main.cc
@@ -185,9 +185,11 @@ main(const int argc, char* argv[]) {
   } catch (const structopt::exception& e) {
     if (argc > 1) {
       int subcommand_index = 1;
-      for (; subcommand_index < argc; ++subcommand_index)
-        if (argv[subcommand_index][0] != '-')
+      for (; subcommand_index < argc; ++subcommand_index) {
+        if (argv[subcommand_index][0] != '-') {
           break;
+        }
+      }
 
       // try correcting typo
       if (const auto sugg = util::lev_distance::find_similar_str(

--- a/src/main.cc
+++ b/src/main.cc
@@ -192,7 +192,8 @@ main(const int argc, char* argv[]) {
       // try correcting typo
       if (const auto sugg = util::lev_distance::find_similar_str(
               argv[subcommand_index], command_list
-          )) {
+          );
+          sugg && *sugg != argv[subcommand_index]) {
         err_logger->error(
             "{}\n"
             "  --> Did you mean `{}`?\n\n"


### PR DESCRIPTION
- suggest subcommand even with flags/options
    - see `poac -v seach` , current `poac` doesn't suggest `search`
- stop subcommand suggestion if subcommand is correct
    - see `poac search` , current `poac` suggest `search` even though the subcommand is correct