### PR TITLE
Add --profile Option

### DIFF
--- a/include/poac/cmd/build.hpp
+++ b/include/poac/cmd/build.hpp
@@ -19,10 +19,13 @@ using core::resolver::ResolvedDeps;
 struct Options : structopt::sub_command {
   /// Build artifacts in release mode, with optimizations
   Option<bool> release = false;
+  /// Build artifacts with the specified profile
+  Option<String> profile;
 };
 
 using FailedToBuild = Error<"failed to build package `{}`", String>;
 using FailedToInstallDeps = Error<"failed to install dependencies">;
+using UnsupportedProfile = Error<"unsupported profile `{}`", String>;
 
 [[nodiscard]] Result<Path>
 build_impl(
@@ -38,6 +41,6 @@ exec(const Options& opts);
 
 } // namespace poac::cmd::build
 
-STRUCTOPT(poac::cmd::build::Options, release);
+STRUCTOPT(poac::cmd::build::Options, release, profile);
 
 #endif // POAC_CMD_BUILD_HPP_

--- a/include/poac/cmd/run.hpp
+++ b/include/poac/cmd/run.hpp
@@ -12,6 +12,8 @@ namespace poac::cmd::run {
 struct Options : structopt::sub_command {
   /// Build artifacts in release mode, with optimizations
   Option<bool> release = false;
+  /// Build artifacts with the specified profile
+  Option<String> profile;
 };
 
 [[nodiscard]] Result<void>
@@ -19,6 +21,6 @@ exec(const Options& opts);
 
 } // namespace poac::cmd::run
 
-STRUCTOPT(poac::cmd::run::Options, release);
+STRUCTOPT(poac::cmd::run::Options, release, profile);
 
 #endif // POAC_CMD_RUN_HPP_

--- a/include/poac/core/validator.hpp
+++ b/include/poac/core/validator.hpp
@@ -80,6 +80,9 @@ valid_description(StringRef desc);
 [[nodiscard]] Result<data::manifest::PartialPackage, String>
 valid_manifest(const toml::value& manifest);
 
+[[nodiscard]] Result<Option<String>, String>
+valid_profile(const Option<String>& profile, Option<bool> release);
+
 } // namespace poac::core::validator
 
 #endif // POAC_CORE_VALIDATOR_HPP_

--- a/lib/cmd/build.cc
+++ b/lib/cmd/build.cc
@@ -44,7 +44,15 @@ build(const Options& opts, const toml::value& manifest) {
     return Ok(None);
   }
 
-  const Mode mode = opts.release.value() ? Mode::release : Mode::debug;
+  const auto profile =
+      Try(core::validator::valid_profile(opts.profile, opts.release)
+              .map_err(to_anyhow))
+          .value_or("debug");
+  if (profile != "debug" && profile != "release") {
+    return Err<UnsupportedProfile>(profile);
+  }
+
+  const Mode mode = profile == "release" ? Mode::release : Mode::debug;
   const Path output_path = Try(build_impl(manifest, mode, resolved_deps));
   return Ok(output_path);
 }

--- a/lib/cmd/run.cc
+++ b/lib/cmd/run.cc
@@ -21,9 +21,10 @@ exec(const Options& opts) {
   const String name = toml::find<String>(manifest, "package", "name");
 
   const Option<Path> output = Try(
-      build::build({.release = opts.release}, manifest).with_context([&name] {
-        return Err<build::FailedToBuild>(name).get();
-      })
+      build::build({.release = opts.release, .profile = opts.profile}, manifest)
+          .with_context([&name] {
+            return Err<build::FailedToBuild>(name).get();
+          })
   );
   if (!output.has_value()) {
     return Ok();

--- a/lib/core/validator.cc
+++ b/lib/core/validator.cc
@@ -384,13 +384,7 @@ valid_manifest(const toml::value& manifest) {
 
 [[nodiscard]] Result<Option<String>, String>
 valid_profile(const Option<String>& profile, Option<bool> release) {
-  if (not release.has_value() || not release.value()) {
-    if (profile.has_value()) {
-      return Ok(profile.value());
-    } else {
-      return Ok(None);
-    }
-  } else {
+  if (release.has_value() && release.value()) {
     if (profile.has_value() && profile.value() != "release") {
       return Err(format(
           "Specified profiles are conflicted: you specify --release and --profile={}.",
@@ -398,6 +392,12 @@ valid_profile(const Option<String>& profile, Option<bool> release) {
       ));
     } else {
       return Ok("release");
+    }
+  } else {
+    if (profile.has_value()) {
+      return Ok(profile.value());
+    } else {
+      return Ok(None);
     }
   }
 }

--- a/lib/core/validator.cc
+++ b/lib/core/validator.cc
@@ -382,4 +382,24 @@ valid_manifest(const toml::value& manifest) {
   return Ok(package);
 }
 
+[[nodiscard]] Result<Option<String>, String>
+valid_profile(const Option<String>& profile, Option<bool> release) {
+  if (not release.has_value() || not release.value()) {
+    if (profile.has_value()) {
+      return Ok(profile.value());
+    } else {
+      return Ok(None);
+    }
+  } else {
+    if (profile.has_value() && profile.value() != "release") {
+      return Err(format(
+          "Specified profiles are conflicted: you specify --release and --profile={}.",
+          profile.value()
+      ));
+    } else {
+      return Ok("release");
+    }
+  }
+}
+
 } // namespace poac::core::validator

--- a/tests/unit/core/validator.cc
+++ b/tests/unit/core/validator.cc
@@ -236,12 +236,12 @@ description = "Manifest Test library"
     {
       auto x = valid_profile(None, None);
       expect(x.is_ok());
-      expect(not x.unwrap().has_value());
+      expect(!x.unwrap().has_value());
     }
     {
       auto x = valid_profile(None, false);
       expect(x.is_ok());
-      expect(not x.unwrap().has_value());
+      expect(!x.unwrap().has_value());
     }
     {
       auto x = valid_profile(None, true);

--- a/tests/unit/core/validator.cc
+++ b/tests/unit/core/validator.cc
@@ -228,4 +228,39 @@ description = "Manifest Test library"
       );
     })) << "incorrect data type";
   };
+
+  "test valid_profile"_test = [] {
+    using poac::core::validator::valid_profile;
+    using poac::None;
+
+    {
+      auto x = valid_profile(None, None);
+      expect(x.is_ok());
+      expect(not x.unwrap().has_value());
+    }
+    {
+      auto x = valid_profile(None, false);
+      expect(x.is_ok());
+      expect(not x.unwrap().has_value());
+    }
+    {
+      auto x = valid_profile(None, true);
+      expect(x.is_ok());
+      expect(x.unwrap() == "release");
+    }
+    {
+      auto x = valid_profile("debug", None);
+      expect(x.is_ok());
+      expect(x.unwrap() == "debug");
+    }
+    {
+      auto x = valid_profile("debug", false);
+      expect(x.is_ok());
+      expect(x.unwrap() == "debug");
+    }
+    {
+      auto x = valid_profile("debug", true);
+      expect(x.is_err());
+    }
+  };
 }


### PR DESCRIPTION
This PR adds `--profile` option to `build` and `run` subcommands.

#### Consideration

`cargo` has some default profiles, and one of that for developing named `dev` outputs `target/debug/*` .
In this PR I named `debug` for that, but if you mind, it's better to change before merge.

#### FAQ

- Q. Why does `valid_profile` return `Result<Option<String>, String>` , 
    - instead of `Result<core::builder::ninja::build::Mode, String>` or something like that?
        - I don't know the plan, but if `poac` is aspiring to be like `cargo` , `poac` will support user-defined profiles.
    - instead of `Result<String, String>` with return value `"debug"` if `valid_profile(None, false)` or `valid_profile(None, None)` ?
        - To reuse this function to implement `clean` subcommand. `clean` needs to recognize **unspecified** , `--profile=debug` , and release mode (`--profile=release` and/or `--release`). `None` returned by `valid_profile` indicates above **unspecified** .