### PR TITLE
Support finding a manifest file in parent directories

### DIFF
--- a/include/poac/cmd/fmt.hpp
+++ b/include/poac/cmd/fmt.hpp
@@ -18,9 +18,6 @@ struct Options : structopt::sub_command {
 };
 
 [[nodiscard]] Result<void>
-fmt(StringRef args);
-
-[[nodiscard]] Result<void>
 exec(const Options& opts);
 
 } // namespace poac::cmd::fmt

--- a/include/poac/cmd/lint.hpp
+++ b/include/poac/cmd/lint.hpp
@@ -16,15 +16,6 @@ struct Options : structopt::sub_command {
   // FIXME(ken-matsui): this is structopt limitation; I'd remove this.
 };
 
-inline const Path config_file(config::path::cwd / "CPPLINT.cfg");
-
-using CppLintNotFound = Error<
-    "`lint` command requires `cpplint`; try installing it by:\n"
-    "  pip install cpplint">;
-
-[[nodiscard]] Result<void>
-lint(StringRef name, Option<String> args);
-
 [[nodiscard]] Result<void>
 exec([[maybe_unused]] const Options& opts);
 

--- a/include/poac/util/validator.hpp
+++ b/include/poac/util/validator.hpp
@@ -11,8 +11,8 @@
 
 namespace poac::util::validator {
 
-[[nodiscard]] Result<void, String>
-required_config_exists(const Path& base = config::path::cwd) noexcept;
+[[nodiscard]] Result<Path, String>
+required_config_exists() noexcept;
 
 [[nodiscard]] Result<void, String>
 can_create_directory(const Path& p);

--- a/lib/cmd/fmt.cc
+++ b/lib/cmd/fmt.cc
@@ -94,7 +94,8 @@ exec(const Options& opts) {
 
   spdlog::trace("Parsing the manifest file: {} ...", manifest_path);
   // TODO(ken-matsui): parse as a static type rather than toml::value
-  const toml::value manifest = toml::parse(manifest_path);
+  const toml::value manifest =
+      toml::parse(relative(manifest_path, config::path::cwd));
   String name = toml::find<String>(manifest, "package", "name");
   if (name.empty()) {
     log::warn("project name is empty; try setting anything you want.");

--- a/lib/cmd/lint.cc
+++ b/lib/cmd/lint.cc
@@ -57,7 +57,8 @@ exec([[maybe_unused]] const Options& opts) {
 
   spdlog::trace("Parsing the manifest file: {} ...", manifest_path);
   // TODO(ken-matsui): parse as a static type rather than toml::value
-  const toml::value manifest = toml::parse(manifest_path);
+  const toml::value manifest =
+      toml::parse(relative(manifest_path, config::path::cwd));
   const String name = toml::find<String>(manifest, "package", "name");
 
   const Path base_dir = manifest_path.parent_path();

--- a/lib/cmd/lint.cc
+++ b/lib/cmd/lint.cc
@@ -14,13 +14,19 @@
 
 namespace poac::cmd::lint {
 
+inline constexpr StringRef config_name = "CPPLINT.cfg";
+
+using CppLintNotFound = Error<
+    "`lint` command requires `cpplint`; try installing it by:\n"
+    "  pip install cpplint">;
+
 [[nodiscard]] Result<void>
-lint(StringRef name, Option<String> args) {
+lint(StringRef name, const Path& base_dir, Option<String> args) {
   log::status("Linting", name);
 
-  String cpplint = "cpplint ";
+  String cpplint = format("cd {} && cpplint ", base_dir.string());
   if (!args.has_value()) {
-    spdlog::trace("Using cpplint config file ({}) ...", config_file);
+    spdlog::trace("Using cpplint config file: {} ...", base_dir / config_name);
   } else {
     spdlog::trace("Using pre-configured arguments ...");
     cpplint += format("{} ", args.value());
@@ -46,16 +52,20 @@ exec([[maybe_unused]] const Options& opts) {
   }
 
   spdlog::trace("Checking if required config exists ...");
-  Try(util::validator::required_config_exists().map_err(to_anyhow));
+  const Path manifest_path =
+      Try(util::validator::required_config_exists().map_err(to_anyhow));
 
-  spdlog::trace("Parsing the manifest file ...");
+  spdlog::trace("Parsing the manifest file: {} ...", manifest_path);
   // TODO(ken-matsui): parse as a static type rather than toml::value
-  const toml::value manifest = toml::parse(data::manifest::name);
+  const toml::value manifest = toml::parse(manifest_path);
   const String name = toml::find<String>(manifest, "package", "name");
 
-  spdlog::trace("Checking if cpplint config ({}) exists ...", config_file);
-  if (fs::exists(config_file)) {
-    return lint(name, None);
+  const Path base_dir = manifest_path.parent_path();
+  const Path config_path = base_dir / config_name;
+  spdlog::trace("Checking if cpplint config exists: {} ...", config_path);
+  if (fs::exists(config_path)) {
+    spdlog::trace("Using cpplint config file: {} ...", config_path);
+    return lint(name, base_dir, None);
   }
 
   String args;
@@ -65,7 +75,7 @@ exec([[maybe_unused]] const Options& opts) {
   if (2011 < toml::find<i64>(manifest, "package", "edition")) {
     args += "--filter=-build/c++11 ";
   }
-  return lint(name, args);
+  return lint(name, base_dir, args);
 }
 
 } // namespace poac::cmd::lint

--- a/lib/util/validator.cc
+++ b/lib/util/validator.cc
@@ -15,12 +15,15 @@ required_config_exists() noexcept {
   while (true) {
     std::error_code ec{};
     const Path config_path = candidate / data::manifest::name;
+    spdlog::trace("Finding manifest: {} ...", config_path);
     if (fs::exists(config_path, ec)) {
       return Ok(config_path);
     }
 
-    if (candidate.has_parent_path()) {
-      candidate = candidate.parent_path();
+    const Path parent_path = candidate.parent_path();
+    if (candidate.has_parent_path()
+        && parent_path != candidate.root_directory()) {
+      candidate = parent_path;
     } else {
       break;
     }

--- a/lib/util/validator.cc
+++ b/lib/util/validator.cc
@@ -8,16 +8,26 @@
 
 namespace poac::util::validator {
 
-[[nodiscard]] Result<void, String>
-required_config_exists(const Path& base) noexcept {
-  const auto config_path = base / data::manifest::name;
-  std::error_code ec{};
-  if (fs::exists(config_path, ec)) {
-    return Ok();
+[[nodiscard]] Result<Path, String>
+required_config_exists() noexcept {
+  // TODO(ken-matsui): move out to data/manifest.hpp
+  Path candidate = config::path::cwd;
+  while (true) {
+    std::error_code ec{};
+    const Path config_path = candidate / data::manifest::name;
+    if (fs::exists(config_path, ec)) {
+      return Ok(config_path);
+    }
+
+    if (candidate.has_parent_path()) {
+      candidate = candidate.parent_path();
+    } else {
+      break;
+    }
   }
-  return Err(
-      format("required manifest file `{}` does not exist", data::manifest::name)
-  );
+  return Err(format(
+      "could not find `{}` here and in its parents", data::manifest::name
+  ));
 }
 
 [[nodiscard]] Result<void, String>

--- a/tests/ui/fmt/no-manifest.stderr
+++ b/tests/ui/fmt/no-manifest.stderr
@@ -1,1 +1,1 @@
-Error: required manifest file `poac.toml` does not exist
+Error: could not find `poac.toml` here and in its parents


### PR DESCRIPTION
For `fmt` & `lint` commands, when we are inside of a Poac project, Poac executes those commands from the project root wherever we are.

Before this PR:

```console
you:~/hello_world$ poac fmt
  Formatting hello_world

you:~/hello_world/build$ poac fmt
Error: required manifest file `poac.toml` does not exist
```

This PR lets:

```console
you:~/hello_world$ poac fmt
  Formatting hello_world

you:~/hello_world/build$ poac fmt
  Formatting hello_world
```